### PR TITLE
calculate the final url in the proxy

### DIFF
--- a/auth/tests/test.py
+++ b/auth/tests/test.py
@@ -116,9 +116,9 @@ class TestZippy(BaseTestCase):
             self.get(url).status_code
 
     def test_ok(self):
-        assert self.get(self.url).status_code, 200
+        assert self.get(self.url + '/something?else=1').status_code, 200
         self.req.get.assert_called_with(
-            'https://b.c/some/url/', verify=True,
+            'https://b.c/something?else=1', verify=True,
             data='', timeout=30,
             headers={'Authorization': mock.ANY}
         )

--- a/auth/tests/test_utils.py
+++ b/auth/tests/test_utils.py
@@ -79,3 +79,11 @@ class TestSend(BaseTestCase):
         eq_(res.status_code, 201)
         eq_(res.content, 'foo')
         eq_(res['Content-Type'], 'app/xml')
+
+
+def test_url():
+    req = RequestFactory().get(
+        '/v1/reference/reference/bar?q=1',
+        **{settings.HEADER_DESTINATION: 'http://foo.com'})
+    eq_(utils.reference_url(req, utils.prepare(req), 'reference'),
+        'http://foo.com/bar?q=1')

--- a/auth/utils.py
+++ b/auth/utils.py
@@ -1,6 +1,8 @@
 from logging import getLogger
+from urlparse import urlsplit, urlunsplit
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 
 import requests
@@ -98,3 +100,17 @@ class BraintreeGateway(object):
     """
     def __init__(self):
         self.config = BraintreeConfig()
+
+
+def reference_url(request, parsed_request, reference_name):
+    """
+    The reference url is a combination of:
+    * the server name passed in the HTTP header
+    * the trailing URL after the proxy URL
+    * the query string
+    """
+    root = len(reverse('reference', kwargs={'reference_name': reference_name}))
+    scheme, netloc, path, query, fragment = urlsplit(parsed_request['url'])
+    path = request.META['PATH_INFO'][root:]
+    query = request.META.get('QUERY_STRING', '')
+    return urlunsplit((scheme, netloc, path, query, fragment))

--- a/auth/views.py
+++ b/auth/views.py
@@ -5,9 +5,10 @@ from curling.lib import sign_request
 from lxml import etree
 
 from django.conf import settings
+
 from django.http import HttpResponse
 
-from utils import BraintreeGateway, prepare, send
+from utils import BraintreeGateway, prepare, reference_url, send
 
 from braintree.environment import Environment
 from braintree.webhook_notification_gateway import WebhookNotificationGateway
@@ -124,6 +125,8 @@ def reference(request, reference_name):
         raise ValueError('Unknown provider: {}'.format(reference_name))
 
     new_request = prepare(request)
+    new_request['url'] = reference_url(request, new_request, reference_name)
+
     sign_request(
         None,
         settings.ZIPPY_CONFIGURATION[reference_name]['auth'],


### PR DESCRIPTION
- copy (and slightly improve) the code from solitude lib/proxy over
- calculate the final URL of a zippy request in the proxy, not in solitude
- add a test for that.
